### PR TITLE
Divide check logic for URLs in Navbar for About from others

### DIFF
--- a/layouts/_partials/header/navbar.html
+++ b/layouts/_partials/header/navbar.html
@@ -12,8 +12,12 @@
                 {{ $currentURL := .Page.RelPermalink }}
                 {{ range .Site.Menus.main }}
                 <li class="nav-item">
-                    <a class="nav-link {{ if hasPrefix $currentURL .URL }}active{{ end }}" {{ if hasPrefix $currentURL
-                        .URL }}aria-current="page" {{ end }} href="{{ .URL }}">{{ .Name }}</a>
+                    <a class="nav-link {{ if (or (and (eq .URL "/") (eq $currentURL "/")) (and (ne .URL "/") (hasPrefix $currentURL .URL))) }}active{{ end }}"
+                        {{ if (or (and (eq .URL "/") (eq $currentURL "/")) (and (ne .URL "/") (hasPrefix $currentURL .URL))) }}aria-current="page"{{ end }}
+                        href="{{ .URL }}"
+                    >
+                        {{ .Name }}
+                    </a>
                 </li>
                 {{ end }}
                 <li class="nav-item">


### PR DESCRIPTION
About에 대한 페이지 체크 부분만 별도로 동작하게 수정하여 Navbar에서 현재 탭을 정확하게 보일 수 있도록 수정.

Closes #14 